### PR TITLE
chore: pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,12 +1,12 @@
 version: 1
-generated_at: 2026-06-15T13:16:05Z
+generated_at: 2026-06-15T17:51:13Z
 internal: []
 trusted:
   - action: actions/cache
     refs:
-      - v2
+      - 8492260343ad570701412c2f464a5877dc76bace
     occurrences:
-      v2:
+      8492260343ad570701412c2f464a5877dc76bace:
         .github/workflows/latest_conformance.yml:
           - jobs.latest-conformance-test.steps.[4].uses
         .github/workflows/main.yml:

--- a/.github/workflows/latest_conformance.yml
+++ b/.github/workflows/latest_conformance.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Cache built Protobuf source
         id: cache-protobuf-source
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: protobuf
           key: ${{ runner.os }}-protobuf-${{ steps.get-protobuf-sha.outputs.sha }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}-elixir-${{ matrix.elixir }}-erlang-${{ matrix.otp }}
@@ -65,7 +65,7 @@ jobs:
       # Don't cache PLTs based on mix.lock hash, as Dialyzer can incrementally update even old ones
       # Cache key based on Elixir & Erlang version (also useful when running in matrix)
       - name: Cache Dialyzer's PLT
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         id: cache-plt
         with:
           path: priv/plts
@@ -150,7 +150,7 @@ jobs:
 
       - name: Cache Elixir dependencies with compiled protoc
         id: cache-deps-with-built-protoc
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: deps
           key: ${{ runner.os }}-mix-deps-with-protoc-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
## Summary
- Pins **all** GitHub Actions to immutable commit SHAs — both external third-party actions and internal `platform-tribe-actions` references

## How it was generated

The following commands were run in sequence from the repository root:

```
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-bump-internal.js
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-pin-external.js --pin-all
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
```

- `actions-lockfile-produce.js` — generates/updates `.github/actions.lock.yaml` from current workflow refs
- `actions-lockfile-bump-internal.js` — resolves internal (`platform-tribe-actions`) action refs to their current SHA
- `actions-lockfile-pin-external.js --pin-all` — resolves all external action refs to their current SHA